### PR TITLE
fix error caused by catch(e)

### DIFF
--- a/test.ts
+++ b/test.ts
@@ -49,7 +49,7 @@ const runTests = (algName: string, alg: Algorithm) => { // Separate scope for na
 
     try {
       assert.deepStrictEqual(getArray(doc), expectedResult)
-    } catch(e) {
+    } catch(e: any) {
       console.log()
       alg.printDoc(doc)
       throw e


### PR DESCRIPTION
I compile with tsc  v4.4.3 and get this error:
```txt
test.ts:81:21 - error TS2571: Object is of type 'unknown'.
81         console.log(e.stack)
                       ~
Found 1 error.
```
After some searching, I found this: 
https://stackoverflow.com/questions/68240884/error-object-inside-catch-is-of-type-unkown